### PR TITLE
Fix extending selections and other small bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "indentation-level-movement",
-  "version": "1.1.1",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,8 +2,11 @@
   "name": "indentation-level-movement",
   "displayName": "Indentation Level Movement",
   "description": "Fast and efficient vertical movement.",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "publisher": "kaiwood",
+  "contributors": [
+    "juko"
+  ],
   "icon": "images/indentation-level-movement-icon.png",
   "license": "MIT",
   "bugs": "https://github.com/kaiwood/vscode-indentation-level-movement/issues",


### PR DESCRIPTION
Hey! 

Thanks for the awesome package, was looking for something similar since I'm used to jump_along_indent on sublime text!

Just some qol changes that make it closer resemble the original sublime plugin (which might not be your exact goal, but I think overall they're beneficial)

- Fixes for when you try to extend your current selection
- Fix for handling start and ends of files
- Fixes for using active instead of start so it won't get confused after having a selection already
- Added some more typing where needed